### PR TITLE
Naprawiony kolor plusów w panelu "aktywne wpisy"

### DIFF
--- a/style.css
+++ b/style.css
@@ -295,3 +295,6 @@
 [data-night-mode] section.search-input form .popper-button button {
     background: #cad0d0
 }
+section.entry > header > .right > div > span {
+    color: #39a684!important
+}


### PR DESCRIPTION
Plusy na wpisach w panelu "aktywne wpisy" z prawej strony mirko zamiast pomarańczowych są teraz zielone - tak, jak Pan Jezus powiedział:
![obraz](https://user-images.githubusercontent.com/18292081/213282590-15b6ff12-d797-431a-a834-f92c4e247e12.png)
