### PR TITLE
Remove `.right .username > span` override

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,10 +99,6 @@
 [data-night-mode] header > .right path {
     fill: #cad0d0
 }
-[data-night-mode] .right .username > span {
-    font-weight: 700;
-    font-size: 14px
-}
 [data-night-mode] section.entry-voters ul li a.username>span {
     font-weight: normal
 }


### PR DESCRIPTION
Poprawili wielkość nicków: https://wykop.pl/wpis/70096383/wykopowicze-wracamy-do-was-z-kolejnymi-zmianami-kt

@tentin-quarantino: Na których stronach znajdują się nicki z selectora `.last .username > span`?

## Before
![image](https://user-images.githubusercontent.com/905878/213499887-1716b1b9-f88c-42ac-ae5d-511f76e2f420.png)

## After
![image](https://user-images.githubusercontent.com/905878/213500031-4ebd2f98-e152-4989-b03e-1b91fc4f5c54.png)
